### PR TITLE
Removed check for notification reason

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -163,13 +163,7 @@ export default {
 		filter(notifications) {
 			// only keep the unread ones with specific reasons
 			return notifications.filter((n) => {
-				return (
-					n.unread
-					&& (
-						['assign', 'mention', 'review_requested'].includes(n.reason)
-						|| (n.reason === 'subscribed' && n.subject?.type === 'Release')
-					)
-				)
+				return (n.unread)
 			})
 		},
 		onUnsubscribe(item) {


### PR DESCRIPTION
This mirrors the GitHub notification page instead of just filtering for specific reasons.
With this check, one was for example unable to see activity in own issues because the reason was `author`