### PR TITLE
Add admin default access token in settings for link previews and search

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -79,6 +79,7 @@ class ConfigController extends Controller {
 	 *
 	 * @param array $values key/value pairs to store in user preferences
 	 * @return DataResponse
+	 * @throws PreConditionNotMetException
 	 */
 	public function setConfig(array $values): DataResponse {
 		// revoke the oauth token if needed

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -32,12 +32,14 @@ class Admin implements ISettings {
 		$clientSecret = $this->config->getAppValue(Application::APP_ID, 'client_secret');
 		$usePopup = $this->config->getAppValue(Application::APP_ID, 'use_popup', '0');
 		$adminLinkPreviewEnabled = $this->config->getAppValue(Application::APP_ID, 'link_preview_enabled', '1') === '1';
+		$defaultLinkToken = $this->config->getAppValue(Application::APP_ID, 'default_link_token');
 
 		$adminConfig = [
 			'client_id' => $clientID,
 			'client_secret' => $clientSecret,
 			'use_popup' => ($usePopup === '1'),
 			'link_preview_enabled' => $adminLinkPreviewEnabled,
+			'default_link_token' => $defaultLinkToken,
 		];
 		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
 		return new TemplateResponse(Application::APP_ID, 'adminSettings');

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -51,6 +51,24 @@
 					@input="onInput"
 					@focus="readonly = false">
 			</div>
+			<br>
+			<p class="settings-hint">
+				<InformationOutlineIcon :size="20" class="icon" />
+				{{ t('integration_github', 'This default token will be used for link previews and unified search by users who didn\'t connect to GitHub.') }}
+			</p>
+			<div class="line">
+				<label for="github-link-token">
+					<KeyIcon :size="20" class="icon" />
+					{{ t('integration_github', 'Default access token') }}
+				</label>
+				<input id="github-link-token"
+					v-model="state.default_link_token"
+					type="password"
+					:readonly="readonly"
+					:placeholder="t('integration_github', 'personal access token')"
+					@input="onInput"
+					@focus="readonly = false">
+			</div>
 			<NcCheckboxRadioSwitch
 				:checked="state.use_popup"
 				@update:checked="onCheckboxChanged($event, 'use_popup')">
@@ -59,7 +77,7 @@
 			<NcCheckboxRadioSwitch
 				:checked="state.link_preview_enabled"
 				@update:checked="onCheckboxChanged($event, 'link_preview_enabled')">
-				{{ t('integration_github', 'Enable GitHub link previews in Talk') }}
+				{{ t('integration_github', 'Enable GitHub link previews') }}
 			</NcCheckboxRadioSwitch>
 		</div>
 	</div>
@@ -116,6 +134,7 @@ export default {
 				this.saveOptions({
 					client_id: this.state.client_id,
 					client_secret: this.state.client_secret,
+					default_link_token: this.state.default_link_token,
 				})
 			}, 2000)()
 		},


### PR DESCRIPTION
closes #46

User token is used in priority. Fallback to system-wide token only happens for search and link previews requests.