### PR TITLE
Fix permalink resolving when ref contains slashes

### DIFF
--- a/lib/Service/GithubAPIService.php
+++ b/lib/Service/GithubAPIService.php
@@ -377,6 +377,11 @@ class GithubAPIService {
 		return $this->request($userId, $endpoint, $params, 'GET', true);
 	}
 
+	public function getCommitInfo(?string $userId, string $owner, string $repo, string $ref): array {
+		$endpoint = 'repos/' . $owner . '/' . $repo . '/commits/' . $ref;
+		return $this->request($userId, $endpoint, [], 'GET', true);
+	}
+
 	/**
 	 * Make an authenticated HTTP request to GitHub API
 	 * @param string|null $userId

--- a/lib/Service/GithubAPIService.php
+++ b/lib/Service/GithubAPIService.php
@@ -283,7 +283,7 @@ class GithubAPIService {
 	 * @return array
 	 */
 	public function getUserInfo(?string $userId, string $githubUserName): array {
-		return $this->request($userId, 'users/' . $githubUserName, [], 'GET', true);
+		return $this->request($userId, 'users/' . $githubUserName, [], 'GET', true, 5);
 	}
 
 	/**
@@ -298,7 +298,7 @@ class GithubAPIService {
 			'subject_type' => $subjectType,
 			'subject_id' => $subjectId,
 		];
-		return $this->request($userId, 'users/' . $githubUserName . '/hovercard', $params, 'GET', true);
+		return $this->request($userId, 'users/' . $githubUserName . '/hovercard', $params, 'GET', true, 5);
 	}
 
 	/**
@@ -310,7 +310,7 @@ class GithubAPIService {
 	 */
 	public function getIssueInfo(?string $userId, string $owner, string $repo, int $issueNumber): array {
 		$endpoint = 'repos/' . $owner . '/' . $repo . '/issues/' . $issueNumber;
-		return $this->request($userId, $endpoint, [], 'GET', true);
+		return $this->request($userId, $endpoint, [], 'GET', true, 5);
 	}
 
 	/**
@@ -322,7 +322,7 @@ class GithubAPIService {
 	 */
 	public function getIssueReactionsInfo(?string $userId, string $owner, string $repo, int $issueNumber): array {
 		$endpoint = 'repos/' . $owner . '/' . $repo . '/issues/' . $issueNumber . '/reactions';
-		return $this->request($userId, $endpoint, [], 'GET', true);
+		return $this->request($userId, $endpoint, [], 'GET', true, 5);
 	}
 
 	/**
@@ -334,7 +334,7 @@ class GithubAPIService {
 	 */
 	public function getIssueCommentInfo(?string $userId, string $owner, string $repo, int $commentId): array {
 		$endpoint = 'repos/' . $owner . '/' . $repo . '/issues/comments/' . $commentId;
-		return $this->request($userId, $endpoint, [], 'GET', true);
+		return $this->request($userId, $endpoint, [], 'GET', true, 5);
 	}
 
 	/**
@@ -346,7 +346,7 @@ class GithubAPIService {
 	 */
 	public function getIssueCommentReactionsInfo(?string $userId, string $owner, string $repo, int $commentId): array {
 		$endpoint = 'repos/' . $owner . '/' . $repo . '/issues/comments/' . $commentId . '/reactions';
-		return $this->request($userId, $endpoint, [], 'GET', true);
+		return $this->request($userId, $endpoint, [], 'GET', true, 5);
 	}
 
 	/**
@@ -358,7 +358,7 @@ class GithubAPIService {
 	 */
 	public function getPrInfo(?string $userId, string $owner, string $repo, int $prNumber): array {
 		$endpoint = 'repos/' . $owner . '/' . $repo . '/pulls/' . $prNumber;
-		return $this->request($userId, $endpoint, [], 'GET', true);
+		return $this->request($userId, $endpoint, [], 'GET', true, 5);
 	}
 
 	/**
@@ -374,12 +374,12 @@ class GithubAPIService {
 		$params = [
 			'ref' => $ref,
 		];
-		return $this->request($userId, $endpoint, $params, 'GET', true);
+		return $this->request($userId, $endpoint, $params, 'GET', true, 5);
 	}
 
 	public function getCommitInfo(?string $userId, string $owner, string $repo, string $ref): array {
 		$endpoint = 'repos/' . $owner . '/' . $repo . '/commits/' . $ref;
-		return $this->request($userId, $endpoint, [], 'GET', true);
+		return $this->request($userId, $endpoint, [], 'GET', true, 5);
 	}
 
 	/**
@@ -389,12 +389,15 @@ class GithubAPIService {
 	 * @param array $params Query parameters (key/val pairs)
 	 * @param string $method HTTP query method
 	 * @param bool $useDefaultToken
+	 * @param int $timeout
 	 * @return array decoded request result or error
 	 */
-	public function request(?string $userId, string $endPoint, array $params = [], string $method = 'GET', bool $useDefaultToken = false): array {
+	public function request(?string $userId, string $endPoint, array $params = [], string $method = 'GET',
+							bool $useDefaultToken = false, int $timeout = 30): array {
 		try {
 			$url = 'https://api.github.com/' . $endPoint;
 			$options = [
+				'timeout' => $timeout,
 				'headers' => [
 					'User-Agent' => 'Nextcloud GitHub integration',
 				],

--- a/src/views/GithubCodePermalinkReferenceWidget.vue
+++ b/src/views/GithubCodePermalinkReferenceWidget.vue
@@ -134,7 +134,10 @@ export default {
 				: t('integration_github', 'Line {line}', { line: this.richObject.lineBegin })
 		},
 		shortRef() {
-			return this.richObject.ref.slice(0, 7)
+			if (this.richObject.ref.original_ref === this.richObject.ref.sha) {
+				return this.richObject.ref.original_ref
+			}
+			return this.richObject.ref.original_ref + ' ' + this.richObject.ref.sha
 		},
 		textContent() {
 			let content = ''

--- a/src/views/GithubCodePermalinkReferenceWidget.vue
+++ b/src/views/GithubCodePermalinkReferenceWidget.vue
@@ -135,9 +135,9 @@ export default {
 		},
 		shortRef() {
 			if (this.richObject.ref.original_ref === this.richObject.ref.sha) {
-				return this.richObject.ref.original_ref
+				return this.richObject.ref.sha.slice(0, 7)
 			}
-			return this.richObject.ref.original_ref + ' ' + this.richObject.ref.sha
+			return this.richObject.ref.original_ref + ' ' + this.richObject.ref.sha.slice(0, 7)
 		},
 		textContent() {
 			let content = ''


### PR DESCRIPTION
closes #61

This is costly but I found no smarter way...

What's done now is to take the ref+path and loop to try to get the commit info from the longest candidate to the shortest. For example, with https://github.com/nextcloud/richdocuments/blob/testing/direct_edit/lib/Controller/WopiController.php#L22 , those requests will be made to `api.github.com/repos/nextcloud/richdocuments/commits/REF`:
* `testing/direct_edit/lib/Controller`
* `testing/direct_edit/lib`
* `testing/direct_edit` which is successful