### PR TITLE
Add default token restriction

### DIFF
--- a/lib/Service/GithubAPIService.php
+++ b/lib/Service/GithubAPIService.php
@@ -400,7 +400,9 @@ class GithubAPIService {
 			if ($userId !== null) {
 				$accessToken = $this->config->getUserValue($userId, Application::APP_ID, 'token');
 			}
-			if ($accessToken === '' && $useDefaultToken) {
+			// only use the default token if authenticated or if default_link_token_require_auth is disabled
+			$defaultLinkTokenRequireAuth = $this->config->getAppValue(Application::APP_ID, 'default_link_token_require_auth', '1') === '1';
+			if ($accessToken === '' && $useDefaultToken && ($userId !== null || !$defaultLinkTokenRequireAuth)) {
 				$accessToken = $this->config->getAppValue(Application::APP_ID, 'default_link_token');
 			}
 			if ($accessToken !== '') {

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -33,6 +33,7 @@ class Admin implements ISettings {
 		$usePopup = $this->config->getAppValue(Application::APP_ID, 'use_popup', '0');
 		$adminLinkPreviewEnabled = $this->config->getAppValue(Application::APP_ID, 'link_preview_enabled', '1') === '1';
 		$defaultLinkToken = $this->config->getAppValue(Application::APP_ID, 'default_link_token');
+		$defaultLinkTokenRequireAuth = $this->config->getAppValue(Application::APP_ID, 'default_link_token_require_auth', '1') === '1';
 
 		$adminConfig = [
 			'client_id' => $clientID,
@@ -40,6 +41,7 @@ class Admin implements ISettings {
 			'use_popup' => ($usePopup === '1'),
 			'link_preview_enabled' => $adminLinkPreviewEnabled,
 			'default_link_token' => $defaultLinkToken,
+			'default_link_token_require_auth' => $defaultLinkTokenRequireAuth,
 		];
 		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
 		return new TemplateResponse(Application::APP_ID, 'adminSettings');

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -65,10 +65,19 @@
 					v-model="state.default_link_token"
 					type="password"
 					:readonly="readonly"
-					:placeholder="t('integration_github', 'personal access token')"
+					:placeholder="t('integration_github', 'access token')"
 					@input="onInput"
 					@focus="readonly = false">
 			</div>
+			<p v-if="state.default_link_token" id="default-token-warning" class="settings-hint">
+				<AlertIcon :size="20" class="icon" />
+				{{ t('integration_github', 'Warning: The default token can access private repositories of its owner.') }}
+			</p>
+			<NcCheckboxRadioSwitch
+				:checked="state.default_link_token_require_auth"
+				@update:checked="onCheckboxChanged($event, 'default_link_token_require_auth')">
+				{{ t('integration_github', 'Only use the default token with authenticated users') }}
+			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
 				:checked="state.use_popup"
 				@update:checked="onCheckboxChanged($event, 'use_popup')">
@@ -86,6 +95,7 @@
 <script>
 import InformationOutlineIcon from 'vue-material-design-icons/InformationOutline.vue'
 import KeyIcon from 'vue-material-design-icons/Key.vue'
+import AlertIcon from 'vue-material-design-icons/Alert.vue'
 
 import GithubIcon from './icons/GithubIcon.vue'
 
@@ -105,6 +115,7 @@ export default {
 		NcCheckboxRadioSwitch,
 		KeyIcon,
 		InformationOutlineIcon,
+		AlertIcon,
 	},
 
 	props: [],
@@ -135,6 +146,7 @@ export default {
 					client_id: this.state.client_id,
 					client_secret: this.state.client_secret,
 					default_link_token: this.state.default_link_token,
+					default_link_token_require_auth: this.state.default_link_token_require_auth,
 				})
 			}, 2000)()
 		},
@@ -188,6 +200,10 @@ export default {
 		> input {
 			width: 300px;
 		}
+	}
+
+	#default-token-warning {
+		margin-top: 8px;
 	}
 }
 </style>


### PR DESCRIPTION
Close https://github.com/nextcloud/integration_github/issues/62

* Add a warning stating the default token can access private repos
* Add an admin setting to only use the default token for authenticated users

What about guest users? Do we consider them authenticated or anonymous? :grin: