### PR TITLE
Lazy load dashboard widget and reference widgets

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -1,5 +1,3 @@
-/* jshint esversion: 6 */
-
 /**
  * Nextcloud - github
  *
@@ -11,17 +9,17 @@
  * @copyright Julien Veyssier 2020
  */
 
-import Vue from 'vue'
-import './bootstrap.js'
-import Dashboard from './views/Dashboard.vue'
+__webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
+__webpack_public_path__ = OC.linkTo('integration_github', 'js/') // eslint-disable-line
 
-document.addEventListener('DOMContentLoaded', function() {
-
-	OCA.Dashboard.register('github_notifications', (el, { widget }) => {
+document.addEventListener('DOMContentLoaded', () => {
+	OCA.Dashboard.register('github_notifications', async (el, { widget }) => {
+		const { default: Vue } = await import(/* webpackChunkName: "dashboard-lazy" */'vue')
+		const { default: Dashboard } = await import(/* webpackChunkName: "dashboard-lazy" */'./views/Dashboard.vue')
+		Vue.mixin({ methods: { t, n } })
 		const View = Vue.extend(Dashboard)
 		new View({
 			propsData: { title: widget.title },
 		}).$mount(el)
 	})
-
 })

--- a/src/reference.js
+++ b/src/reference.js
@@ -20,12 +20,14 @@
  */
 
 import { registerWidget } from '@nextcloud/vue-richtext'
-import './bootstrap.js'
-import Vue from 'vue'
-import GithubIssuePrReferenceWidget from './views/GithubIssuePrReferenceWidget.vue'
-import GithubCodePermalinkReferenceWidget from './views/GithubCodePermalinkReferenceWidget.vue'
 
-registerWidget('integration_github_issue_pr', (el, { richObjectType, richObject, accessible }) => {
+__webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
+__webpack_public_path__ = OC.linkTo('integration_github', 'js/') // eslint-disable-line
+
+registerWidget('integration_github_issue_pr', async (el, { richObjectType, richObject, accessible }) => {
+	const { default: Vue } = await import(/* webpackChunkName: "reference-issue-lazy" */'vue')
+	const { default: GithubIssuePrReferenceWidget } = await import(/* webpackChunkName: "reference-issue-lazy" */'./views/GithubIssuePrReferenceWidget.vue')
+	Vue.mixin({ methods: { t, n } })
 	const Widget = Vue.extend(GithubIssuePrReferenceWidget)
 	new Widget({
 		propsData: {
@@ -36,7 +38,10 @@ registerWidget('integration_github_issue_pr', (el, { richObjectType, richObject,
 	}).$mount(el)
 })
 
-registerWidget('integration_github_code_permalink', (el, { richObjectType, richObject, accessible }) => {
+registerWidget('integration_github_code_permalink', async (el, { richObjectType, richObject, accessible }) => {
+	const { default: Vue } = await import(/* webpackChunkName: "reference-permalink-lazy" */'vue')
+	const { default: GithubCodePermalinkReferenceWidget } = await import(/* webpackChunkName: "reference-permalink-lazy" */'./views/GithubCodePermalinkReferenceWidget.vue')
+	Vue.mixin({ methods: { t, n } })
 	const Widget = Vue.extend(GithubCodePermalinkReferenceWidget)
 	new Widget({
 		propsData: {


### PR DESCRIPTION
I tried to make it so only one file per chunk would be generated but I still don't get it. Anyway, leaving the Webpack `optimization` config empty just works fine, leaving it do a split storm :grin:.

So, this works fine. Any objection to leave `optimization` empty?