### PR TITLE
Prepare 3.0.0

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 module.exports = {
 	globals: {
 		appVersion: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.0 – 2024-09-28
+
+### Changed
+
+- Switch from Webpack to Vite
+- Update npm pkgs
+- Support NC 30
+- Add SPDX headers
+
+### Fixed
+
+- fix crash when connecting to an account without display name
+
 ## 2.0.7 – 2024-03-06
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     <description><![CDATA[GitHub integration provides a dashboard widget displaying your most important notifications
     and a unified search provider for repositories, issues and pull requests. It also provides a link reference provider
     to render links to issues, pull requests and comments in Talk and Text.]]></description>
-    <version>2.0.7</version>
+    <version>3.0.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Github</namespace>


### PR DESCRIPTION
### Changed

- Switch from Webpack to Vite
- Update npm pkgs
- Support NC 30
- Add SPDX headers

### Fixed

- fix crash when connecting to an account without display name