### PR TITLE
fix: pass `hasInteractiveView: false` to non-interactive widgets

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -17,7 +17,7 @@ registerWidget('integration_github_issue_pr', async (el, { richObjectType, richO
 			accessible,
 		},
 	}).$mount(el)
-})
+}, () => {}, { hasInteractiveView: false })
 
 registerWidget('integration_github_code_permalink', async (el, { richObjectType, richObject, accessible }) => {
 	const { default: Vue } = await import(/* webpackChunkName: "reference-permalink-lazy" */'vue')
@@ -31,4 +31,4 @@ registerWidget('integration_github_code_permalink', async (el, { richObjectType,
 			accessible,
 		},
 	}).$mount(el)
-})
+}, () => {}, { hasInteractiveView: false })


### PR DESCRIPTION
prop `hasInteractiveView: false` should not be passed, if widget doesn't have a second, actually 'interactive' view, as embedded calendar or text app

Before | After
-- | --
<img width="550" alt="2024-11-18_11h28_48" src="https://github.com/user-attachments/assets/badf0a37-1554-4c7e-8703-0381bd056aae"> | <img width="543" alt="image" src="https://github.com/user-attachments/assets/ce2be161-7b7d-4c71-b30a-26a49c32b645">