### PR TITLE
fix: avoid vsprintf ValueError in non-English notification locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.6 - 2026-05-22
+
+### Fixed
+
+- Fix `ValueError` from `vsprintf()` that broke notifications for non-English users (#197).
+
 ## 3.2.5 - 2026-05-16
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     <description><![CDATA[GitHub integration provides a dashboard widget displaying your most important notifications
     and a unified search provider for repositories, issues and pull requests. It also provides a link reference provider
     to render links to issues, pull requests and comments in Talk and Text.]]></description>
-    <version>3.2.5</version>
+    <version>3.2.6</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Github</namespace>

--- a/lib/Notification/GitHubNotifier.php
+++ b/lib/Notification/GitHubNotifier.php
@@ -42,7 +42,7 @@ class GitHubNotifier implements INotifier {
 			case 'new-github-notification':
 				$p = $notification->getSubjectParameters();
 				$newNotifications = (int)($p['newNotifications'] ?? 0);
-				$content = $l->n('You have %s new unread notification with recent activity on GitHub.', 'You have %s new unread notifications with recent activity on GitHub.', $newNotifications, [$newNotifications]);
+				$content = $l->n('You have %n new unread notification with recent activity on GitHub.', 'You have %n new unread notifications with recent activity on GitHub.', $newNotifications);
 
 				$notification->setParsedSubject($content)
 					->setLink('https://github.com/notifications')


### PR DESCRIPTION
Fixes #197.

In `GitHubNotifier::prepare()` the plural message used `%s` as the counter placeholder. With `%s`, Nextcloud's L10N pipeline never sets `%count%` for Symfony's `IdentityTranslator`, so the imploded `"singular|plural"` translation is returned verbatim and `vsprintf` then trips on the extra `%s` — throwing `ValueError` for every non-English user and breaking the notifications API and mail cron until the rows are deleted from the DB.

Switching the counter to `%n` (the Nextcloud convention, see e.g. `integration_onedrive`) lets the L10N layer pass `%count%` and pick the correct plural form before substitution.