### PR TITLE
chore: use the outline style for the key icons

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -37,7 +37,7 @@
 				@focus="readonly = false"
 				@update:model-value="onInput">
 				<template #icon>
-					<KeyIcon :size="20" />
+					<KeyOutlineIcon :size="20" />
 				</template>
 			</NcTextField>
 			<NcTextField
@@ -52,7 +52,7 @@
 				@focus="readonly = false"
 				@update:model-value="onInput">
 				<template #icon>
-					<KeyIcon :size="20" />
+					<KeyOutlineIcon :size="20" />
 				</template>
 			</NcTextField>
 			<br>
@@ -71,7 +71,7 @@
 				@focus="readonly = false"
 				@update:model-value="onInput">
 				<template #icon>
-					<KeyIcon :size="20" />
+					<KeyOutlineIcon :size="20" />
 				</template>
 			</NcTextField>
 			<div v-if="defaultTokenConnected" class="line">
@@ -119,7 +119,7 @@
 </template>
 
 <script>
-import KeyIcon from 'vue-material-design-icons/Key.vue'
+import KeyOutlineIcon from 'vue-material-design-icons/KeyOutline.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 
 import GithubIcon from './icons/GithubIcon.vue'
@@ -146,7 +146,7 @@ export default {
 		NcNoteCard,
 		NcFormBox,
 		NcFormBoxSwitch,
-		KeyIcon,
+		KeyOutlineIcon,
 		CheckIcon,
 	},
 

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -52,7 +52,7 @@
 					@keyup.enter="connectWithToken"
 					@trailing-button-click="state.token = ''">
 					<template #icon>
-						<KeyIcon :size="20" />
+						<KeyOutlineIcon :size="20" />
 					</template>
 				</NcTextField>
 				<NcButton v-if="!connected"
@@ -112,7 +112,7 @@
 
 <script>
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
-import KeyIcon from 'vue-material-design-icons/Key.vue'
+import KeyOutlineIcon from 'vue-material-design-icons/KeyOutline.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 
@@ -140,7 +140,7 @@ export default {
 		NcTextField,
 		NcFormBox,
 		NcFormBoxSwitch,
-		KeyIcon,
+		KeyOutlineIcon,
 		CheckIcon,
 		CloseIcon,
 		OpenInNewIcon,


### PR DESCRIPTION
Switches the `Key` icon to its `KeyOutline` variant in the admin and personal settings, so the API-key fields match the outline style used elsewhere. `integration_jira`, `integration_notion` and `integration_onedrive` already use `KeyOutline` for the same fields.


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
