### PR TITLE
chore: release 3.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.7 - 2026-08-18
+
+### Added
+
+- Added support for Nextcloud 35.
+
+### Fixed
+
+- Keep the settings pages working when a stored secret cannot be decrypted.
+- Update bundled JavaScript dependencies (vite, js-yaml, brace-expansion, `@babel/core`,
+  esbuild, fast-xml-parser, webdav) to close several security advisories.
+
+### Changed
+
+- Use the outline style for the key icons.
+- Updated dependencies & translations.
+
 ## 3.2.6 - 2026-05-22
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     <description><![CDATA[GitHub integration provides a dashboard widget displaying your most important notifications
     and a unified search provider for repositories, issues and pull requests. It also provides a link reference provider
     to render links to issues, pull requests and comments in Talk and Text.]]></description>
-    <version>3.2.6</version>
+    <version>3.2.7</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Github</namespace>


### PR DESCRIPTION
Release cut for 3.2.7: version bump in `appinfo/info.xml` plus the dated changelog
section covering what has landed on `main` since 3.2.6.

The changelog also records Nextcloud 35 support, which shipped in 3.2.5 but was never
documented.

No code changes.
